### PR TITLE
remove indent of image inside frame by creating a style

### DIFF
--- a/etc/styles/OrgOdtStyles.xml
+++ b/etc/styles/OrgOdtStyles.xml
@@ -96,6 +96,13 @@
   <style:style style:name="Text_20_body" style:display-name="Text body" style:family="paragraph" style:parent-style-name="Standard" style:class="text">
    <style:paragraph-properties fo:margin-top="0cm" fo:margin-bottom="0.212cm"/>
   </style:style>
+  <style:style style:name="Text_20_body_noindent" style:display-name="Text body no indent" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="text">
+   <style:paragraph-properties fo:margin-left="0cm" fo:margin-right="0cm" fo:margin-top="0cm"
+                               fo:margin-bottom="0m"
+                               fo:text-indent="0cm"
+                               style:auto-text-indent="false">
+   </style:paragraph-properties>
+  </style:style>
   <style:style style:name="List" style:family="paragraph" style:parent-style-name="Text_20_body" style:class="list">
    <style:text-properties style:font-name-complex="Tahoma1"/>
   </style:style>

--- a/lisp/ox-odt.el
+++ b/lisp/ox-odt.el
@@ -3336,7 +3336,7 @@ used as a communication channel."
 			       (format " draw:name=\"%s\" " short-caption))))
 		    frame-params))
       (let ((text (format "\n<text:p text:style-name=\"%s\">%s</text:p>"
-			  "Text_20_body"
+			  "Text_20_body_noindent"
 			  (apply 'org-odt--frame href width height
 				 (append inner title-and-desc)))))
 	(apply 'org-odt--textbox


### PR DESCRIPTION
The paragraph style of image inside frame is based "Text_20_body", which may bring unwanted indent spaces before image, this pull request remove that indent of image inside frame by creating a style: Text_20_body_noindent.