### PR TITLE
Correctly escape links in odt export.

### DIFF
--- a/lisp/ox-odt.el
+++ b/lisp/ox-odt.el
@@ -3681,7 +3681,7 @@ INFO is a plist holding contextual information.  See
 	 (path
 	  (cond
 	   ((member type '("http" "https" "ftp" "mailto"))
-	    (url-encode-url (org-link-unescape (concat type ":" raw-path))))
+	    (xml-escape-string (org-link-unescape (concat type ":" raw-path))))
 	   ((string= type "file")
 	    (cond
 	     ;; If file path is absolute, prepend it with protocol


### PR DESCRIPTION
There is another fix in the Org repository, but I think this one is more "future proof".  With it you delegate the hard work to the xml library which is already loaded anyway.