### PR TITLE
Fix issue where some styles in style files are overridden

### DIFF
--- a/lisp/ox-odt.el
+++ b/lisp/ox-odt.el
@@ -3925,8 +3925,8 @@ holding export options."
       ;; Update styles.xml with styles that were collected as part of
       ;; `org-odt-hfy-face-to-css' callbacks.
       (goto-char (point-min))
-      (when (re-search-forward "</office:styles>" nil t)
-	(goto-char (match-beginning 0))
+      (when (re-search-forward "<office:styles>" nil t)
+	(goto-char (match-end 0))
 	(insert "\n<!-- Org Htmlfontify Styles -->\n"
 		(cl-loop for style in (plist-get info :odt-hfy-user-sheet-assoc)
 			 concat (format " %s\n" (cddr style)))


### PR DESCRIPTION
When a style file specified using the `ODT_STYLES_FILE` key includes
a style identically named to one of the generated Htmlfontify styles,
the latter overrides the former.

The fix is to put generated Htmlfontify styles at the beginning of the
`<office:styles>` tag contents instead of the end. This way the
`ODT_STYLES_FILE` will take precidence.

Fixes issue #215.
