### PR TITLE
output correct describing text 'scheduled' for scheduled timestamps

### DIFF
--- a/lisp/ox-odt.el
+++ b/lisp/ox-odt.el
@@ -6988,7 +6988,7 @@ channel."
 	     (when scheduled
 	       (concat
 		(format "<text:span text:style-name=\"%s\">%s</text:span>"
-			"OrgScheduledKeyword" org-deadline-string)
+			"OrgScheduledKeyword" org-scheduled-string)
 		(org-odt-timestamp scheduled contents info)))))))
 
 


### PR DESCRIPTION
w/o this fix, the string 'deadline' would be output also for scheduled timestamps.